### PR TITLE
fix: avoid black textures by breaking pot sizes in full mode

### DIFF
--- a/src/core/overlay.ts
+++ b/src/core/overlay.ts
@@ -57,7 +57,9 @@ export async function buildOverlayData(
     pixelToLonLat(ov.x, ov.y + hImg),
   ];
 
-  const imgCanvas = createCanvas(wImg * 2, hImg * 2);
+  const isPowerOfTwo = (n: number) => (n & (n - 1)) === 0;
+  const scale = (style === 'full' && isPowerOfTwo(wImg) && isPowerOfTwo(hImg)) ? 3 : 2;
+  const imgCanvas = createCanvas(wImg * scale, hImg * scale);
   const imgCtx = imgCanvas.getContext('2d', { willReadFrequently: true })! as OffscreenCanvasRenderingContext2D | CanvasRenderingContext2D;
   imgCtx.imageSmoothingEnabled = false;
   imgCtx.fillStyle = transparentPattern;


### PR DESCRIPTION
in full overlay mode, images that are power-of-two (e.g., 64x64, 128x128, etc) render black because of webgl incomplete mipmaps. this change forces npot output for pot inputs by using a 3x scale (istead of 2x), preventing mipmapping

<img width="1177" height="833" alt="image" src="https://github.com/user-attachments/assets/a2effd1a-3892-4d6b-9e5f-002c72d1ddcf" />
